### PR TITLE
Issue: Bot sometimes hangs in stable

### DIFF
--- a/MyFreeFarm_Automat.user.js
+++ b/MyFreeFarm_Automat.user.js
@@ -4527,7 +4527,7 @@ try{
 			break;}
 			case 4:{ // check storage of feed
 				if(unsafeData.prodStock[0][sorte]&&unsafeData.prodStock[0][sorte]>0){
-					autoFarmStable(runId,step+1,didFeed,isBot,sorte,feedcounter,maxFeed);
+					window.setTimeout(autoFarmStable, 3*getRandom(tmin,tmax),runId,step+1,didFeed,isBot,sorte,feedcounter,maxFeed)
 				}else{
 					// feed not found
 					if(1+parseInt(unsafeWindow._currRack,10)<unsafeWindow.userracks){


### PR DESCRIPTION
I have five accounts, each with at least one stable. The (first) stable contains the 'super chicken'. Each stable is fed one 'Getreide'.

When the production has finished and the bot starts handling the stable, it usually hangs on clicking the crop to feed. 'Usually' means, that this happens more often than it doesn't and on each account. Manually selecting the crop makes the bot continuing his business immediately. Consecutive farms on the same account are then handled without issues.

I found out that waiting a few milliseconds solves the issue. And that is, what has been changed. I actually don't know exactly why only the first stable hangs... If I had to guess it's because some initialization stuff for opening the stable takes too long (and the click happens when the dom is not ready yet).
