### PR TITLE
Handling donkey behavior, when using more than one computers to play

### DIFF
--- a/MyFreeFarm_Berater.user.js
+++ b/MyFreeFarm_Berater.user.js
@@ -12402,7 +12402,7 @@ return false;
 			} else {
 				switch(mode) {
 					case "dailydonkey":
-						if (unsafeWindow.donkey_isset && r[1]=="Du hast Waltraud heute schon besucht.") {
+						if (unsafeWindow.donkey_isset && r!=0 && r[0]==0) {
 							for(var i=logDonkey.length-1;i>=0;i--){
 								if(logDonkey[i][0]==todayServerStr){
 									return; // Don't save dummy, if entry for today found


### PR DESCRIPTION
I use several computers to play MFF. When logging in to an account and clicking the donkey, the gained XP and products are correctly put in the "donkey info panel" and the GoToDonkey-Icon vanishes. But if I later login to that account from another computer (where the logDonkey variable isn't filled with an entry for today), clicking the donkey only displays the error message "you have already visited the donkey today".
This patch writes a dummy entry (zero points, no products) into logDonkey in the latter case and hides the GoToDonkey-Icon. Thus, the disturbing flashing GoToDonkey-Icon is disabled for today.

Further the behavior for clicking the donkey without having it already purchased has been changed: The user is now shown the "purchase donkey dialog" instead of an empty "donkey info panel", which makes more sense in my opinion.
